### PR TITLE
Migrate to Infinity Cluster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# dependencies
+/node_modules
+
+# production
+/build
+
+# infrastructure
+infra/*/.terraform*

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ yarn-debug.log*
 yarn-error.log*
 
 # infrastructure
+infra/.terraform*
 infra/*/.terraform*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# BUILD
+FROM node:15.4 as BUILD
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --silent
+COPY . .
+RUN npm run build
+
+# RUN
+FROM nginx:alpine
+COPY --from=BUILD /app/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --from=BUILD /app/build /usr/share/nginx/html
+RUN cat /etc/nginx/nginx.conf
+RUN ls -l /usr/share/nginx/html
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # My "personal website"
 
-I'm not a React expert, or a frontend developer at all really, but I do think I should probably have a "personal website".  
-I'll probably look to populate it with some actual content at a later date, but building this was good experience for learning Route 53, Cloudfront, Certificate Manager, and static site hosting via S3.  
-Terraform was definitely a pain in some areas where the documentation was very light, or even non-existent (e.g. SSL cert must be created in us-east-1 to be used in a CF distro, CF distros must have a particular origin config to use HTTPS, etc).
-
-## System design
-Here is the system layout, quite basic but still very powerful and performant thanks to CloudFront.   
-  
-![](./system_design.svg)  
+This is my personal website
 
 __TODO__:
 - [ ] Refactor infra code into modules, general tidy up

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,0 +1,3 @@
+resource "aws_ecr_repository" "rakmo_ecr" {
+  name = "rakmo.io"
+}

--- a/infra/elb.tf
+++ b/infra/elb.tf
@@ -1,0 +1,23 @@
+resource "aws_lb_target_group" "elb_target_group" {
+    name = "rakmo-elb-target-group"
+    port = 80
+    protocol = "HTTP"
+    vpc_id = local.infinity_vpc_id
+    target_type = "ip"
+}
+
+resource "aws_lb_listener_rule" "rakmo" {
+  listener_arn = local.elb_listener_arn
+  priority     = 1
+
+  action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.elb_target_group.arn
+  }
+
+  condition {
+    host_header {
+      values = ["rakmo.io", "www.rakmo.io"]
+    }
+  }
+}

--- a/infra/local.tf
+++ b/infra/local.tf
@@ -1,0 +1,10 @@
+locals {
+    infinity_vpc_id = data.terraform_remote_state.infinity.outputs.infinity_vpc_id
+    infinity_cluster_id = data.terraform_remote_state.infinity.outputs.infinity_cluster_id
+    elb_security_id = data.terraform_remote_state.infinity.outputs.elb_security_id
+    ecr_repo_url = data.terraform_remote_state.infinity.outputs.ecr_repo_url
+    private_subnet_ids = data.terraform_remote_state.infinity.outputs.private_subnet_ids
+    elb_target_arn = data.terraform_remote_state.infinity.outputs.elb_target_arn
+    elb_listener_arn = data.terraform_remote_state.infinity.outputs.elb_listener_arn
+    ecs_fargate_task_role_arn = data.terraform_remote_state.infinity.outputs.ecs_fargate_task_role_arn
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,32 @@
+terraform {
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+            version = "~> 3.64"
+        }
+    }
+
+    required_version = "~> 1.0"
+
+    backend "s3" {
+        bucket = "infinity-tf-bucket"
+        key = "rakmo.io.tfstate"
+        region = "ap-southeast-2"
+        dynamodb_table = "infinity-tf-state-lock"
+        encrypt = true
+    }
+}
+
+provider "aws" {
+    profile = "default"
+    region = "ap-southeast-2"
+}
+
+data "terraform_remote_state" "infinity" {
+    backend = "s3"
+    config = {
+        bucket = "infinity-tf-bucket"
+        region = "ap-southeast-2"
+        key = "infinity.tfstate"
+    }
+}

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -1,0 +1,18 @@
+resource "aws_security_group" "rakmo_service_security" {
+    name = "rakmo-security-group"
+    vpc_id = local.infinity_vpc_id
+
+    ingress {
+        protocol = "tcp"
+        from_port = 80
+        to_port = 80
+        security_groups = [local.elb_security_id]
+    }
+
+    egress {
+        protocol = "-1"
+        from_port = 0
+        to_port = 0
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}

--- a/infra/service.tf
+++ b/infra/service.tf
@@ -1,0 +1,19 @@
+resource "aws_ecs_service" "example_service" {
+  name            = "rakmo"
+  cluster         = local.infinity_cluster_id
+  task_definition = aws_ecs_task_definition.rakmo_task.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups = [aws_security_group.rakmo_service_security.id]
+    subnets         = local.private_subnet_ids
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.elb_target_group.arn
+    container_name   = "rakmo"
+    container_port   = 80
+  }
+}
+

--- a/infra/task.tf
+++ b/infra/task.tf
@@ -1,0 +1,26 @@
+resource "aws_ecs_task_definition" "rakmo_task" {
+  family = "rakmo"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  memory                   = "2048"
+  cpu                      = "1024"
+  execution_role_arn       = local.ecs_fargate_task_role_arn
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "name": "rakmo",
+    "image": "${aws_ecr_repository.rakmo_ecr.repository_url}:latest",
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ],
+    "cpu": 1024,
+    "memory": 2048,
+    "networkMode": "awsvpc"
+  }
+]
+DEFINITION
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,22 @@
+events {
+    worker_connections 1024;
+}
+
+worker_processes 1;
+
+http {
+    include mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    server {
+        listen 80 default_server;
+        root /usr/share/nginx/html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
### Issues (if applicable)
Fixes #1 

### Description
Migrates to Infinity cluster by spinning up the following infrastructure:
- ECS Task definition
- ECS Service
- ALB Target group, pointing to the private IP of the Task running on the ECS Service
- ALB Listener rule to point the `www.rakmo.io` and `rakmo.io` domains to the rakmo target group

A multi-stage Dockerfile has been added that builds the React app and serves the built application via an Nginx server